### PR TITLE
refactor: signal instead of busy-wait, debug call stack, immutable const bindings, string interpolation, linter fixes

### DIFF
--- a/src/Overture.luau
+++ b/src/Overture.luau
@@ -19,11 +19,15 @@ const CollectionService = game:GetService("CollectionService")
 ]=]
 const Overture = {}
 
-const LibrarySignalCache: { [string]: { BindableEvent } } = {}
-const Libraries: { [string]: ModuleScript } = {}
+const LibrarySignalCache: {[string]: {BindableEvent}} = {}
+const Libraries: {[string]: ModuleScript} = {}
 
 const IsClient = RunService:IsClient()
 local IsDebug = (script:GetAttribute("Debug") == true)
+
+--// Variables
+
+const YIELD_WARN_DELAY = 5
 
 --// Functions
 
@@ -125,31 +129,35 @@ end
 	
 	@error The library `Index` does not exist! -- Thrown on the server, if no ModuleScript exists with the given name.
 ]=]
-function Overture:LoadLibrary(Index: string, NamedImports: { string }?): any?
+function Overture:LoadLibrary(Index: string, NamedImports: {string}?): any?
 	if Libraries[Index] then
 		return RequireModule(Libraries[Index], NamedImports)
 	else
 		assert(IsClient, `The library "{Index}" does not exist!`)
 		
-		LibrarySignalCache[Index] = LibrarySignalCache[Index] or {}
+		LibrarySignalCache[Index] = (LibrarySignalCache[Index] or {})
 		const Signal = Instance.new("BindableEvent")
 		table.insert(LibrarySignalCache[Index], Signal)
 		
 		const CallStack = `{debug.traceback("Stack Begin")}Stack End`
-		local DebugThread: thread?
-		if IsDebug then
-			DebugThread = task.delay(5, function()
-				warn(`Infinite yield possible on 'Overture:LoadLibrary("{Index}")'`)
-				for _, line in CallStack:split("\n") do
-					print(`{line}`)
-				end
-			end)
+		local DebugThread: thread? do
+			if IsDebug then
+				DebugThread = task.delay(YIELD_WARN_DELAY, function()
+					warn(`Infinite yield possible on 'Overture:LoadLibrary("{Index}")'`)
+					
+					for _, line in CallStack:split("\n") do
+						print(`{line}`)
+					end
+				end)
+			end
 		end
 		
 		local Object = Signal.Event:Wait()
+		
 		if DebugThread then
 			pcall(task.cancel, DebugThread)
 		end
+		
 		return RequireModule(Object, NamedImports)
 	end
 end
@@ -264,8 +272,8 @@ task.spawn(BindToTag, "oLibrary", function(Object)
 		return
 	end
 	
-	for _, signal in LibrarySignalCache[Object.Name] do
-		signal:Fire(Object)
+	for _, Signal in LibrarySignalCache[Object.Name] do
+		Signal:Fire(Object)
 	end
 	
 	LibrarySignalCache[Object.Name] = nil

--- a/src/Overture.luau
+++ b/src/Overture.luau
@@ -148,7 +148,7 @@ function Overture:LoadLibrary(Index: string, NamedImports: { string }?): any?
 		
 		local Object = Signal.Event:Wait()
 		if DebugThread then
-			task.cancel(DebugThread)
+			pcall(task.cancel, DebugThread)
 		end
 		return RequireModule(Object, NamedImports)
 	end

--- a/src/Overture.luau
+++ b/src/Overture.luau
@@ -18,10 +18,12 @@ const CollectionService = game:GetService("CollectionService")
 	:::
 ]=]
 const Overture = {}
+
 const LibrarySignalCache: { [string]: { BindableEvent } } = {}
 const Libraries: { [string]: ModuleScript } = {}
+
 const IsClient = RunService:IsClient()
-local IsDebug = script:GetAttribute("Debug") == true
+local IsDebug = (script:GetAttribute("Debug") == true)
 
 --// Functions
 
@@ -38,15 +40,15 @@ const function Retrieve(
 	if ForceWait and RunService:IsRunning() then
 		return InstanceParent:WaitForChild(InstanceName)
 	end
-
+	
 	local SearchInstance = InstanceParent:FindFirstChild(InstanceName)
-
+	
 	if not SearchInstance then
 		SearchInstance = Instance.new(InstanceClass)
 		SearchInstance.Name = InstanceName
 		SearchInstance.Parent = InstanceParent
 	end
-
+	
 	return SearchInstance
 end
 
@@ -61,7 +63,7 @@ const function BindToTag(Tag: string, Function: (Instance) -> ()): RBXScriptConn
 	for _, Value in CollectionService:GetTagged(Tag) do
 		task.spawn(Function, Value)
 	end
-
+	
 	return CollectionService:GetInstanceAddedSignal(Tag):Connect(Function)
 end
 
@@ -76,11 +78,11 @@ const function RequireModule(Module: ModuleScript, NamedImports: { string }?): a
 	if NamedImports then
 		const Exports = require(Module)
 		const Imports = {}
-
+		
 		for ImportIndex, ImportName in ipairs(NamedImports) do
 			Imports[ImportIndex] = Exports[ImportName]
 		end
-
+		
 		return unpack(Imports)
 	else
 		return require(Module)
@@ -128,11 +130,11 @@ function Overture:LoadLibrary(Index: string, NamedImports: { string }?): any?
 		return RequireModule(Libraries[Index], NamedImports)
 	else
 		assert(IsClient, `The library "{Index}" does not exist!`)
-
+		
 		LibrarySignalCache[Index] = LibrarySignalCache[Index] or {}
 		const Signal = Instance.new("BindableEvent")
 		table.insert(LibrarySignalCache[Index], Signal)
-
+		
 		const CallStack = `{debug.traceback("Stack Begin")}Stack End`
 		local DebugThread: thread?
 		if IsDebug then
@@ -143,7 +145,7 @@ function Overture:LoadLibrary(Index: string, NamedImports: { string }?): any?
 				end
 			end)
 		end
-
+		
 		local Object = Signal.Event:Wait()
 		if DebugThread then
 			task.cancel(DebugThread)
@@ -209,7 +211,7 @@ end
 function Overture:Get(InstanceClass: string, InstanceName: string, Parent: Instance?): Instance
 	const SetFolder = (Parent or Retrieve(InstanceClass, "Folder", script, IsClient))
 	const Item = SetFolder:FindFirstChild(InstanceName)
-
+	
 	if Item then
 		return Item
 	elseif not IsClient or not RunService:IsRunning() then
@@ -257,22 +259,22 @@ end
 
 task.spawn(BindToTag, "oLibrary", function(Object)
 	Libraries[Object.Name] = Object
-
+	
 	if not LibrarySignalCache[Object.Name] then
 		return
 	end
-
+	
 	for _, signal in LibrarySignalCache[Object.Name] do
 		signal:Fire(Object)
 	end
-
+	
 	LibrarySignalCache[Object.Name] = nil
 end)
 
-script:GetAttributeChangedSignal("Debug"):Connect(function()
-	IsDebug = script:GetAttribute("Debug") == true
-end)
-
 --// Triggers
+
+script:GetAttributeChangedSignal("Debug"):Connect(function()
+	IsDebug = (script:GetAttribute("Debug") == true)
+end)
 
 return Overture

--- a/src/Overture.luau
+++ b/src/Overture.luau
@@ -1,8 +1,8 @@
 --!nonstrict
 --// Initialization
 
-local RunService = game:GetService("RunService")
-local CollectionService = game:GetService("CollectionService")
+const RunService = game:GetService("RunService")
+const CollectionService = game:GetService("CollectionService")
 
 --[=[
 	@class Overture
@@ -17,9 +17,11 @@ local CollectionService = game:GetService("CollectionService")
 	Remember, all library names in Overture must be unique!
 	:::
 ]=]
-local Overture = {}
-local LibraryThreadCache = {}
-local Libraries: {[string]: ModuleScript} = {}
+const Overture = {}
+const LibrarySignalCache: { [string]: { BindableEvent } } = {}
+const Libraries: { [string]: ModuleScript } = {}
+const IsClient = RunService:IsClient()
+local IsDebug = script:GetAttribute("Debug") == true
 
 --// Functions
 
@@ -27,19 +29,24 @@ local Libraries: {[string]: ModuleScript} = {}
 	@within Overture
 	@ignore
 ]=]
-local function Retrieve(InstanceName: string, InstanceClass: string, InstanceParent: Instance, ForceWait: boolean?): Instance
+const function Retrieve(
+	InstanceName: string,
+	InstanceClass: string,
+	InstanceParent: Instance,
+	ForceWait: boolean?
+): Instance
 	if ForceWait and RunService:IsRunning() then
 		return InstanceParent:WaitForChild(InstanceName)
 	end
-	
+
 	local SearchInstance = InstanceParent:FindFirstChild(InstanceName)
-	
+
 	if not SearchInstance then
 		SearchInstance = Instance.new(InstanceClass)
 		SearchInstance.Name = InstanceName
 		SearchInstance.Parent = InstanceParent
 	end
-	
+
 	return SearchInstance
 end
 
@@ -50,11 +57,11 @@ end
 	@param Tag -- The CollectionService tag
 	@param Function -- The function to call
 ]=]
-local function BindToTag(Tag: string, Function: (Instance) -> ()): RBXScriptConnection
+const function BindToTag(Tag: string, Function: (Instance) -> ()): RBXScriptConnection
 	for _, Value in CollectionService:GetTagged(Tag) do
 		task.spawn(Function, Value)
 	end
-	
+
 	return CollectionService:GetInstanceAddedSignal(Tag):Connect(Function)
 end
 
@@ -64,17 +71,16 @@ end
 	
 	@param Module -- The ModuleScript to require
 	@param NamedImports -- When provided, returns the named variables instead of the entire ModuleScript
-	@return any?
 ]=]
-local function RequireModule(Module: ModuleScript, NamedImports: {string}?)
+const function RequireModule(Module: ModuleScript, NamedImports: { string }?): any?
 	if NamedImports then
-		local Exports = require(Module)
-		local Imports = {}
-		
+		const Exports = require(Module)
+		const Imports = {}
+
 		for ImportIndex, ImportName in ipairs(NamedImports) do
 			Imports[ImportIndex] = Exports[ImportName]
 		end
-		
+
 		return unpack(Imports)
 	else
 		return require(Module)
@@ -114,18 +120,35 @@ end
 	@yields
 	@param Index -- The name of the ModuleScript
 	@param NamedImports -- When provided, returns the named variables instead of the entire ModuleScript
-	@return any?
 	
 	@error The library `Index` does not exist! -- Thrown on the server, if no ModuleScript exists with the given name.
 ]=]
-function Overture:LoadLibrary(Index: string, NamedImports: {string}?)
+function Overture:LoadLibrary(Index: string, NamedImports: { string }?): any?
 	if Libraries[Index] then
 		return RequireModule(Libraries[Index], NamedImports)
 	else
-		assert(not RunService:IsServer(), "The library \"" .. Index .. "\" does not exist!")
-		
-		table.insert(LibraryThreadCache, {Thread = coroutine.running(), RequestedIndex = Index, RequestedAt = time()})
-		return RequireModule(coroutine.yield(), NamedImports)
+		assert(IsClient, `The library "{Index}" does not exist!`)
+
+		LibrarySignalCache[Index] = LibrarySignalCache[Index] or {}
+		const Signal = Instance.new("BindableEvent")
+		table.insert(LibrarySignalCache[Index], Signal)
+
+		const CallStack = `{debug.traceback("Stack Begin")}Stack End`
+		local DebugThread: thread?
+		if IsDebug then
+			DebugThread = task.delay(5, function()
+				warn(`Infinite yield possible on 'Overture:LoadLibrary("{Index}")'`)
+				for _, line in CallStack:split("\n") do
+					print(`{line}`)
+				end
+			end)
+		end
+
+		local Object = Signal.Event:Wait()
+		if DebugThread then
+			task.cancel(DebugThread)
+		end
+		return RequireModule(Object, NamedImports)
 	end
 end
 
@@ -145,12 +168,9 @@ end
 	@yields
 	@client
 	@param ... any
-	@return any?
 ]=]
-function Overture:LoadLibraryOnClient(...)
-	if RunService:IsClient() then
-		return self:LoadLibrary(...)
-	end
+function Overture:LoadLibraryOnClient(...): any?
+	return if IsClient then self:LoadLibrary(...) else nil
 end
 
 --[=[
@@ -168,12 +188,9 @@ end
 	
 	@server
 	@param ... any
-	@return any?
 ]=]
-function Overture:LoadLibraryOnServer(...)
-	if RunService:IsServer() then
-		return self:LoadLibrary(...)
-	end
+function Overture:LoadLibraryOnServer(...): any?
+	return if IsClient then nil else self:LoadLibrary(...)
 end
 
 --[=[
@@ -190,12 +207,12 @@ end
 	@param Parent -- An optional override parent Instance. Useful for retrieving dependencies.
 ]=]
 function Overture:Get(InstanceClass: string, InstanceName: string, Parent: Instance?): Instance
-	local SetFolder = (Parent or Retrieve(InstanceClass, "Folder", script, RunService:IsClient()))
-	local Item = SetFolder:FindFirstChild(InstanceName)
-	
+	const SetFolder = (Parent or Retrieve(InstanceClass, "Folder", script, IsClient))
+	const Item = SetFolder:FindFirstChild(InstanceName)
+
 	if Item then
 		return Item
-	elseif RunService:IsServer() or not RunService:IsRunning() then
+	elseif not IsClient or not RunService:IsRunning() then
 		return Retrieve(InstanceName, InstanceClass, SetFolder)
 	else
 		return SetFolder:WaitForChild(InstanceName)
@@ -234,35 +251,26 @@ end
 	@param Parent -- An optional override parent Instance. Useful for retrieving dependencies.
 ]=]
 function Overture:WaitFor(InstanceClass: string, InstanceName: string, Parent: Instance?): Instance
-	local IsClient = RunService:IsClient()
-	return (Parent or Retrieve(InstanceClass, "Folder", script, IsClient)):WaitForChild(InstanceName, if IsClient then math.huge else nil)
+	return (Parent or Retrieve(InstanceClass, "Folder", script, IsClient) :: any) --// silence linter
+		:WaitForChild(InstanceName, if IsClient then math.huge else nil) :: Instance
 end
 
 task.spawn(BindToTag, "oLibrary", function(Object)
 	Libraries[Object.Name] = Object
-	
-	for _, Cached in LibraryThreadCache do
-		if Object.Name == Cached.RequestedIndex then
-			task.defer(Cached.Thread, Object)
-			task.delay(1, function()
-				table.remove(LibraryThreadCache, table.find(LibraryThreadCache, Cached))
-			end)
-		end
+
+	if not LibrarySignalCache[Object.Name] then
+		return
 	end
+
+	for _, signal in LibrarySignalCache[Object.Name] do
+		signal:Fire(Object)
+	end
+
+	LibrarySignalCache[Object.Name] = nil
 end)
 
-task.spawn(function()
-	while script:GetAttribute("Debug") do
-		task.wait(1)
-		
-		for _, Cached in LibraryThreadCache do
-			if Cached.WarningEmitted then continue end
-			if (time() - Cached.RequestedAt) > 5 then
-				warn(string.format([[Infinite yield possible on Overture:LoadLibrary("%s").]], Cached.RequestedIndex))
-				Cached.WarningEmitted = true
-			end
-		end
-	end
+script:GetAttributeChangedSignal("Debug"):Connect(function()
+	IsDebug = script:GetAttribute("Debug") == true
 end)
 
 --// Triggers

--- a/src/Overture.luau
+++ b/src/Overture.luau
@@ -1,6 +1,7 @@
 --!nonstrict
 --// Initialization
 
+const LogService = game:GetService("LogService")
 const RunService = game:GetService("RunService")
 const CollectionService = game:GetService("CollectionService")
 
@@ -143,10 +144,12 @@ function Overture:LoadLibrary(Index: string, NamedImports: {string}?): any?
 		local DebugThread: thread? do
 			if IsDebug then
 				DebugThread = task.delay(YIELD_WARN_DELAY, function()
-					warn(`Infinite yield possible on 'Overture:LoadLibrary("{Index}")'`)
+					LogService:Warn([[Infinite yield possible on 'Overture:LoadLibrary("{LibraryName}")']], {
+						LibraryName = Index
+					})
 					
 					for _, Line in string.split(CallStack, "\n") do
-						print(Line)
+						LogService:Info(Line)
 					end
 				end)
 			end

--- a/src/Overture.luau
+++ b/src/Overture.luau
@@ -145,8 +145,8 @@ function Overture:LoadLibrary(Index: string, NamedImports: {string}?): any?
 				DebugThread = task.delay(YIELD_WARN_DELAY, function()
 					warn(`Infinite yield possible on 'Overture:LoadLibrary("{Index}")'`)
 					
-					for _, line in CallStack:split("\n") do
-						print(`{line}`)
+					for _, Line in string.split(CallStack, "\n") do
+						print(Line)
 					end
 				end)
 			end


### PR DESCRIPTION
## Library Loading

- Use signals instead of threads and coroutine library.
  This eliminates the need to defer library loading.
- Replace array of data dictionary with a map of module name indices and arrays of `BindableEvent`s.
  This allows for faster retrieval of signals to indicate to `LoadLibrary` calls that the module is loaded, as we do not need to iterate over the whole cache.

## Debugging

- Replace busy-wait "infinite yield" warnings with `BindableEvent` signals
  *Eliminates need to loop over the cache table every second which (especially during start-up) could cause performance degredation.*
  *Also eliminates need to delay cache removal by 1 second which (I believe) was previously done for debug logging purposes.*
  *Allows the "Debug" attribute to be changed during runtime and accordingly reflect onto newly loaded libraries.*
  *(I assume we do not want to rely on packages such as `sleitnick/signal`, to maintain a simple installation process without requiring Wally, hence `BindableEvent`s)*

- Print the current function call stack to console when "infinite yield" warnings are logged.
  [YouTube: Example of call stack logging](https://youtu.be/7-4YoyepLeY)
  *This message has been constructed to resemble the default studio infinite yield warning message.*
  *Unfortunately the blue info text can currently only be achieved via `TestService`, though [Engine API release 717](https://create.roblox.com/docs/release-notes/release-notes-717) suggests we may be able to use `LogService:Info` in the future.*

## Immutable Constant Bindings

- Replace `local` variable assignments to `const` binding declarations wherever appropriate.
  *This [newly available](https://luau.org/syntax/#const-bindings) Luau declaration is great at informing code maintainers and readers that the variable is not going to be re-assigned during runtime.*
  *This declaration can also prevent unintented consequences of variable re-assignment, where perhaps specific parts of the code may not be expecting a variable to change.*

## Miscellaenous

- Use string interpolation over `string.format`.
  *String interpolation is generally favored nowadays over `string.format` for any interpolation that doesn't require formatting specifiers or flags, usually for number representation.*

- Function return types.
  *Some methods didn't include their return type, but still opted to document it for Moonwave.*
  *All functions now properly indicate their return type, which is automatically detected by Moonwave.*

- Linter fixes.
  *The formatting now adheres to the default customs set out by selene and luau-lsp.*
  *The defaults may not be favored by everyone, but following them does improve readability and (importantly) consistency.*